### PR TITLE
Fix bed skip at night

### DIFF
--- a/asuna_awards/awards/enter_sandman.lua
+++ b/asuna_awards/awards/enter_sandman.lua
@@ -12,6 +12,7 @@ return function(award)
           awards.unlock(player_name,award)
         end
       end
+      ogbsn()
     end
   else
     local ogborc = beds.on_rightclick


### PR DESCRIPTION
A trivial fix: asuna_awards was storing the original bed_skip function, but never actually called it, with the result that skipping the night didn't work anymore.